### PR TITLE
Updates to make server single-threaded

### DIFF
--- a/python/gaas_client/gaas_thrift.py
+++ b/python/gaas_client/gaas_thrift.py
@@ -15,7 +15,15 @@
 import io
 
 import thriftpy2
-from thriftpy2.rpc import make_server, make_client
+from thriftpy2.rpc import make_client
+from thriftpy2.protocol import TBinaryProtocolFactory
+from thriftpy2.server import TSimpleServer
+from thriftpy2.thrift import TProcessor
+from thriftpy2.transport import (
+    TBufferedTransportFactory,
+    TServerSocket,
+    TTransportException,
+)
 
 
 # This is the Thrift input file as a string rather than a separate file. This
@@ -115,7 +123,7 @@ service GaasService {
            2:i32 max_depth,
            3:i32 graph_id
            ) throws (1:GaasError e),
-           
+
   list<i32> get_edge_IDs_for_vertices(1:list<i32> src_vert_IDs,
                                       2:list<i32> dst_vert_IDs,
                                       3:i32 graph_id
@@ -170,6 +178,7 @@ service GaasService {
 spec = thriftpy2.load_fp(io.StringIO(gaas_thrift_spec),
                          module_name="gaas_thrift")
 
+
 def create_server(handler, host, port):
     """
     Return a server object configured to listen on host/port and use the handler
@@ -182,7 +191,17 @@ def create_server(handler, host, port):
     this module. However, this function is likely only called from the
     gaas_server package which depends on the code in this package.
     """
-    return make_server(spec.GaasService, handler, host, port)
+    proto_factory = TBinaryProtocolFactory()
+    trans_factory = TBufferedTransportFactory()
+    client_timeout = 3000
+
+    processor = TProcessor(spec.GaasService, handler)
+    server_socket = TServerSocket(host=host, port=port,
+                                  client_timeout=client_timeout)
+    server = TSimpleServer(processor, server_socket,
+                           iprot_factory=proto_factory,
+                           itrans_factory=trans_factory)
+    return server
 
 
 def create_client(host, port, call_timeout=90000):
@@ -197,8 +216,8 @@ def create_client(host, port, call_timeout=90000):
     try:
         return make_client(spec.GaasService, host=host, port=port,
                            timeout=call_timeout)
-    except thriftpy2.transport.TTransportException:
-        # Rasie a GaaS exception in order to completely encapsulate all Thrift
+    except TTransportException:
+        # Raise a GaaS exception in order to completely encapsulate all Thrift
         # details in this module. If this was not done, callers of this function
         # would have to import thriftpy2 in order to catch the
         # TTransportException, which then leaks thriftpy2.

--- a/python/tests/client1_script.py
+++ b/python/tests/client1_script.py
@@ -1,0 +1,35 @@
+import random
+import time
+from pathlib import Path
+
+from gaas_client import GaasClient
+
+
+_data_dir = (Path(__file__).parent)/"data"
+
+edgelist_csv_data = {
+    "karate": {"csv_file_name":
+               (_data_dir/"karate.csv").absolute().as_posix(),
+               "dtypes": ["int32", "int32", "float32"],
+               "num_edges": 156,
+               },
+}
+
+client = GaasClient()
+
+test_data = edgelist_csv_data["karate"]
+client.load_csv_as_edge_data(test_data["csv_file_name"],
+                             dtypes=test_data["dtypes"],
+                             vertex_col_names=["0", "1"],
+                             type_name="")
+time.sleep(10)
+n = int(random.random() * 1000)
+
+#print(f"---> starting {n}", flush=True)
+
+for i in range(1000000):
+    extracted_gid = client.extract_subgraph(allow_multi_edges=False)
+    #client.delete_graph(extracted_gid)
+    #print(f"---> {n}: extracted {extracted_gid}", flush=True)
+
+#print(f"---> done {n}", flush=True)

--- a/python/tests/client2_script.py
+++ b/python/tests/client2_script.py
@@ -1,6 +1,5 @@
 import time
 import random
-from pathlib import Path
 
 from gaas_client import GaasClient
 

--- a/python/tests/client2_script.py
+++ b/python/tests/client2_script.py
@@ -1,0 +1,19 @@
+import time
+import random
+from pathlib import Path
+
+from gaas_client import GaasClient
+
+client = GaasClient()
+
+time.sleep(10)
+n = int(random.random() * 1000)
+
+#print(f"---> starting {n}", flush=True)
+
+for i in range(1000000):
+    extracted_gid = client.extract_subgraph(allow_multi_edges=False)
+    #client.delete_graph(extracted_gid)
+    #print(f"---> {n}: extracted {extracted_gid}", flush=True)
+
+#print(f"---> done {n}", flush=True)

--- a/python/tests/multi_client_test_runner.sh
+++ b/python/tests/multi_client_test_runner.sh
@@ -1,0 +1,11 @@
+# source this script (ie. do not run it) for easier job control from the shell
+# FIXME: change this and/or GaaS so PYTHONPATH is not needed
+PYTHONPATH=/Projects/GaaS/python python client1_script.py &
+sleep 1
+PYTHONPATH=/Projects/GaaS/python python client2_script.py &
+PYTHONPATH=/Projects/GaaS/python python client2_script.py &
+PYTHONPATH=/Projects/GaaS/python python client2_script.py &
+PYTHONPATH=/Projects/GaaS/python python client2_script.py &
+PYTHONPATH=/Projects/GaaS/python python client2_script.py &
+PYTHONPATH=/Projects/GaaS/python python client2_script.py &
+PYTHONPATH=/Projects/GaaS/python python client2_script.py


### PR DESCRIPTION
Updates to make server single-threaded. Also added some crude test scripts to ensure 8 clients can concurrently access the server without problems.

Context: the default server returned by Thriftpy2's `make_server()` helper is multi-threaded, but the current cugraph APIs called by GaaS are not thread-safe, so the incoming requests must be serialized by using Thrift's `TSimpleServer` class. Using the default `TThreadedServer` was causing multiple clients (specifically DGL training threads/processes) to experience errors.

cc @VibhuJawa 